### PR TITLE
Fixed building on cordova 6.4.0 on ios

### DIFF
--- a/src/ios/TwitterPlugin.h
+++ b/src/ios/TwitterPlugin.h
@@ -9,7 +9,6 @@
     #import <Social/Social.h>
     #import <Accounts/Accounts.h>
     #import <Cordova/CDVPlugin.h>
-    #import <Cordova/CDVJSON.h>
 
 
 @interface TwitterPlugin : CDVPlugin{

--- a/src/ios/TwitterPlugin.m
+++ b/src/ios/TwitterPlugin.m
@@ -6,11 +6,27 @@
 //  Modify by Jesus Torres on 03/23/14.
 
 #import "TwitterPlugin.h"
-#import <Cordova/CDVJSON.h>
 #import <Cordova/CDVAvailability.h>
 #import <Social/Social.h>
 
 #define TWITTER_URL @"https://api.twitter.com/1.1/"
+
+@interface NSString (CDVJSONSerializing)
+- (id)JSONObject;
+@end
+
+@implementation NSString (CDVJSONSerializing)
+- (id)JSONObject {
+    NSError * error = nil;
+    id dict = [NSJSONSerialization JSONObjectWithData:[self dataUsingEncoding:NSUTF8StringEncoding]
+                                                         options:NSJSONReadingMutableContainers
+                                                           error:&error];
+    if (error != nil) {
+        NSLog(@"NSString can't be converted to an NSArray/NSDictionary error: %@", [error localizedDescription]);
+    }
+    return dict;
+}
+@end
 
 @implementation TwitterPlugin
 


### PR DESCRIPTION
In cordova 6 there is no CDVJSON.h header as it was removed so the project didn't build.
This merge request should fix it as it uses NSJSONSerialization instead, as suggested by the cordova team.